### PR TITLE
Test against PouchDB and PouchDB Server

### DIFF
--- a/bin/test-pouchdb-all.sh
+++ b/bin/test-pouchdb-all.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+#
+# sample script showing all the different ways you can
+# test sqldown against pouchdb
+#
+
+# leveldown in the client, leveldown in the server
+npm run test-pouchdb
+
+# sqldown in the client, leveldown in the server
+LEVEL_ADAPTER=../../.. npm run test-pouchdb
+
+# leveldown in the client, sqldown in the server
+SERVER_ARGS='--level-backend ../../..' npm run test-pouchdb
+
+# sqldown in the client, sqldown in the server
+SERVER_ARGS='--level-backend ../../..' LEVEL_ADAPTER=../../.. npm run test-pouchdb
+
+# leveldown in the server, firefox as the client (also available: phantomjs)
+CLIENT=selenium:firefox npm run test-pouchdb
+
+# sqldown in the server, firefox as the client (also available: phantomjs)
+CLIENT=selenium:firefox SERVER_ARGS='--level-backend ../../..' npm run test-pouchdb

--- a/bin/test-pouchdb.sh
+++ b/bin/test-pouchdb.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+#
+# run a single pouchdb test, using pouchdb-server
+# in the server running on port 6984
+#
+
+./node_modules/.bin/pouchdb-server -p 6984 $SERVER_ARGS &
+POUCHDB_SERVER_PID=$!
+
+cd node_modules/pouchdb/
+npm install
+
+COUCH_HOST=http://localhost:6984 npm test
+
+EXIT_STATUS=$?
+if [[ ! -z $POUCHDB_SERVER_PID ]]; then
+  kill $POUCHDB_SERVER_PID
+fi
+exit $EXIT_STATUS

--- a/package.json
+++ b/package.json
@@ -19,10 +19,13 @@
     "sqlite3": "^2.2.0"
   },
   "devDependencies": {
+    "pouchdb": "git://github.com/pouchdb/pouchdb#2415",
+    "pouchdb-server": "0.4.0",
     "tape": "^2.12.1"
   },
   "scripts": {
-    "test": "node ./test/test.js"
+    "test": "node ./test/test.js",
+    "test-pouchdb": "./bin/test-pouchdb.sh"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
This is just an example of how you could set up SQLdown to test against PouchDB and PouchDB server, following instructions from [here](https://gist.github.com/nolanlawson/f2f4d7e2e6f426502b94).  The `test-pouchdb-all.sh` script just contains whatever client/server combinations I could think of off the top of my head.

BTW the tests currently fail with:

```
  1) test.replication.js-local-http Test _conflicts key:
     Uncaught TypeError: Cannot read property 'rows' of undefined
      at /Users/nolanlawson/workspace/sqldown/node_modules/pouchdb/tests/test.replication.js:465:18
      at /Users/nolanlawson/workspace/sqldown/node_modules/pouchdb/node_modules/pouchdb-mapreduce/utils.js:29:9
      at process._tickCallback (node.js:419:13)
```
